### PR TITLE
Fix blurred MenuItem in HiDPI mode [Linux]

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
@@ -833,41 +833,26 @@ public void setImage (Image image) {
 		ImageList imageList = parent.imageList;
 		if (imageList == null) imageList = parent.imageList = new ImageList ();
 		int imageIndex = imageList.indexOf (image);
-		long pixbuf = 0;
 		if (imageIndex == -1) {
 			imageIndex = imageList.add (image);
-			pixbuf = imageList.getPixbuf (imageIndex);
-            /*
-             * Bug in GTK the default renderer does scale again on pixbuf.
-             * Need to scaledown here and no need to scaledown id device scale is 1
-             *
-             * We should resize pixbuf and update pixbuf array in the imagelist only if
-             * the image is added to the imagelist in this call. If the image is already
-             * add imageList.getPixbuf returns resized pixbuf.
-             */
-            if (DPIUtil.useCairoAutoScale()) {
-                Rectangle imgSize = image.getBounds();
-                long scaledPixbuf = GDK.gdk_pixbuf_scale_simple(pixbuf, imgSize.width, imgSize.height, GDK.GDK_INTERP_BILINEAR);
-                if (scaledPixbuf !=0) {
-                    pixbuf = scaledPixbuf;
-                }
-                imageList.replacePixbuf(imageIndex, pixbuf);
-            }
 		} else {
 			imageList.put (imageIndex, image);
-			pixbuf = imageList.getPixbuf (imageIndex);
 		}
+
+		long pixbuf = imageList.getPixbuf (imageIndex);
 
 		if (!GTK.GTK_IS_MENU_ITEM (handle)) return;
 		if (OS.SWT_PADDED_MENU_ITEMS && imageHandle != 0) {
-			GTK.gtk_image_set_from_pixbuf(imageHandle, pixbuf);
+		    GTK.gtk_image_set_from_gicon(imageHandle, pixbuf, GTK.GTK_ICON_SIZE_MENU);
 		} else {
 			if (imageHandle == 0 && boxHandle != 0) {
-				imageHandle = GTK.gtk_image_new_from_pixbuf (pixbuf);
+			    imageHandle = GTK.gtk_image_new ();
+			    if (imageHandle == 0) error (SWT.ERROR_NO_HANDLES);
+			    GTK.gtk_image_set_from_gicon(imageHandle, pixbuf, GTK.GTK_ICON_SIZE_MENU);
 				GTK.gtk_container_add (boxHandle, imageHandle);
 				GTK.gtk_box_reorder_child (boxHandle, imageHandle, 0);
 			} else {
-				GTK.gtk_image_set_from_pixbuf(imageHandle, pixbuf);
+			    GTK.gtk_image_set_from_gicon(imageHandle, pixbuf, GTK.GTK_ICON_SIZE_MENU);
 			}
 			if (boxHandle == 0) error (SWT.ERROR_NO_HANDLES);
 		}

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.110.0.lgc20200505-1900
+Bundle-Version: 3.110.0.lgc20200601-1600
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -19,7 +19,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.110.0.lgc20200505-1900</version>
+    <version>3.110.0.lgc20200601-1600</version>
     <packaging>eclipse-plugin</packaging>
       
     <properties>


### PR DESCRIPTION
Problem: blurred menu items within SWT applications in HiDPI mode
http://tfs:8080/tfs/IMPT/_api/_wit/DownloadAttachment?fileName=before_fix_1.png&attachmentId=808327&contentOnly=true&__v=5
http://tfs:8080/tfs/IMPT/_api/_wit/DownloadAttachment?fileName=before_fix_2.png&attachmentId=808328&contentOnly=true&__v=5
http://tfs:8080/tfs/IMPT/_api/_wit/DownloadAttachment?fileName=before_fix_3.png&attachmentId=808329&contentOnly=true&__v=5

Analysis: SWT uses two ways for supplying images: 
1. gdk_pixbuf
2. Cairo surface

Cairo surface is not used to draw MenuItem image but it scales original pixbuf (which contains dpi aware data)
https://github.com/eclipse/eclipse.platform.swt/blob/415f94a4ceca8db4fae42b7020da3426dd8eca5a/bundles/org.eclipse.swt/Eclipse%20SWT/gtk/org/eclipse/swt/widgets/MenuItem.java#L848

scaled pixbuf used to draw image 
https://github.com/eclipse/eclipse.platform.swt/blob/415f94a4ceca8db4fae42b7020da3426dd8eca5a/bundles/org.eclipse.swt/Eclipse%20SWT/gtk/org/eclipse/swt/widgets/MenuItem.java#L863

Fix: use GtkImage instead of scaled pixbuf

Result: 
http://tfs:8080/tfs/IMPT/_api/_wit/DownloadAttachment?fileName=after_fix_1.png&attachmentId=808330&contentOnly=true&__v=5
http://tfs:8080/tfs/IMPT/_api/_wit/DownloadAttachment?fileName=after_fix_2.png&attachmentId=808330&contentOnly=true&__v=5
http://tfs:8080/tfs/IMPT/_api/_wit/DownloadAttachment?fileName=after_fix_3.png&attachmentId=808330&contentOnly=true&__v=5

This fix can be suggested to eclipse community once it will be fixed with DSG