### PR TITLE
Fix blurred Tree/Table Icons in HiDPI

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -809,7 +809,12 @@ void createRenderers (long /*int*/ columnHandle, int modelIndex, boolean check, 
 	 * no images. Fix for Bug 457196. NOTE: this change has been ported to Tables since Tables/Trees both
 	 * use the same underlying GTK structure.
 	 */
-	GTK.gtk_tree_view_column_add_attribute (columnHandle, pixbufRenderer, OS.pixbuf, modelIndex + CELL_PIXBUF);
+	// commented to fix blurred icons in HiDPI mode
+    // should be uncommented when we will have proper fix
+    // for Bug 562468 & 534422
+    //GTK.gtk_tree_view_column_add_attribute (columnHandle, pixbufRenderer, OS.pixbuf, modelIndex + CELL_PIXBUF);
+    GTK.gtk_tree_view_column_add_attribute (columnHandle, pixbufRenderer, OS.gicon, modelIndex + CELL_PIXBUF);
+
 	if (!ownerDraw) {
 		GTK.gtk_tree_view_column_add_attribute (columnHandle, pixbufRenderer, OS.cell_background_rgba, BACKGROUND_COLUMN);
 		GTK.gtk_tree_view_column_add_attribute (columnHandle, textRenderer, OS.cell_background_rgba, BACKGROUND_COLUMN);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableItem.java
@@ -1153,6 +1153,12 @@ public void setImage (int index, Image image) {
 		if (imageIndex == -1) {
             imageIndex = imageList.add (image);
             pixbuf = imageList.getPixbuf (imageIndex);
+
+
+            // commented to fix blurred icons in HiDPI mode
+            // should be uncommented when we will have proper fix
+            // for Bug 562468 & 534422
+
             /*
              * Reset size of pixbufRenderer if we have an image being set that is larger
              * than the current size of the pixbufRenderer. Fix for bug 457196.
@@ -1163,7 +1169,7 @@ public void setImage (int index, Image image) {
              * change has been ported to Tables since Tables/Trees both use the same
              * underlying GTK structure.
              */
-            if (DPIUtil.useCairoAutoScale()) {
+            //if (DPIUtil.useCairoAutoScale()) {
                 /*
                  * Bug in GTK the default renderer does scale again on pixbuf.
                  * Need to scaledown here and no need to scaledown id device scale is 1
@@ -1172,7 +1178,7 @@ public void setImage (int index, Image image) {
                  * the image is added to the imagelist in this call. If the image is already
                  * add imageList.getPixbuf returns resized pixbuf.
                  */
-
+                /*
                 if ((DPIUtil.getDeviceZoom() != 100)) {
                     Rectangle imgSize = image.getBounds();
                     long scaledPixbuf = GDK.gdk_pixbuf_scale_simple(pixbuf, imgSize.width, imgSize.height, GDK.GDK_INTERP_BILINEAR);
@@ -1181,7 +1187,8 @@ public void setImage (int index, Image image) {
                     }
                     imageList.replacePixbuf(imageIndex, pixbuf);
                 }
-            }
+                */
+            //}
         } else {
             pixbuf = imageList.getPixbuf (imageIndex);
         }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -957,7 +957,12 @@ void createRenderers (long /*int*/ columnHandle, int modelIndex, boolean check, 
 	 * no images. Fix for Bug 469277 & 476419. NOTE: this change has been ported to Tables since Tables/Trees both
 	 * use the same underlying GTK structure.
 	 */
-	GTK.gtk_tree_view_column_add_attribute (columnHandle, pixbufRenderer, OS.pixbuf, modelIndex + CELL_PIXBUF);
+	// commented to fix blurred icons in HiDPI mode
+    // should be uncommented when we will have proper fix
+    // for Bug 562468 & 534422
+	//GTK.gtk_tree_view_column_add_attribute (columnHandle, pixbufRenderer, OS.pixbuf, modelIndex + CELL_PIXBUF);
+	GTK.gtk_tree_view_column_add_attribute (columnHandle, pixbufRenderer, OS.gicon, modelIndex + CELL_PIXBUF);
+
 	if (!ownerDraw) {
 		GTK.gtk_tree_view_column_add_attribute (columnHandle, pixbufRenderer, OS.cell_background_rgba, BACKGROUND_COLUMN);
 		GTK.gtk_tree_view_column_add_attribute (columnHandle, textRenderer, OS.cell_background_rgba, BACKGROUND_COLUMN);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -1504,6 +1504,12 @@ public void setImage (int index, Image image) {
 		if (imageIndex == -1) {
             imageIndex = imageList.add (image);
             pixbuf = imageList.getPixbuf (imageIndex);
+
+
+            // commented to fix blurred icons in HiDPI mode
+            // should be uncommented when we will have proper fix
+            // for Bug 562468 & 534422
+
             /*
              * Reset size of pixbufRenderer if we have an image being set that is larger
              * than the current size of the pixbufRenderer. Fix for Bug 469277 & 476419.
@@ -1514,7 +1520,7 @@ public void setImage (int index, Image image) {
              * change has been ported to Tables since Tables/Trees both use the same
              * underlying GTK structure.
              */
-            if (DPIUtil.useCairoAutoScale()) {
+            //if (DPIUtil.useCairoAutoScale()) {
                 /*
                  * Bug in GTK the default renderer does scale again on pixbuf.
                  * Need to scaledown here and no need to scaledown id device scale is 1
@@ -1523,6 +1529,7 @@ public void setImage (int index, Image image) {
                  * the image is added to the imagelist in this call. If the image is already
                  * add imageList.getPixbuf returns resized pixbuf.
                  */
+                /*
                 if ((DPIUtil.getDeviceZoom() != 100)) {
                     Rectangle imgSize = image.getBounds();
                     long scaledPixbuf = GDK.gdk_pixbuf_scale_simple(pixbuf, imgSize.width, imgSize.height, GDK.GDK_INTERP_BILINEAR);
@@ -1531,7 +1538,8 @@ public void setImage (int index, Image image) {
                     }
                     imageList.replacePixbuf(imageIndex, pixbuf);
                 }
-            }
+                */
+            //}
         } else {
             pixbuf = imageList.getPixbuf (imageIndex);
         }

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.110.0.lgc20200601-1600
+Bundle-Version: 3.110.0.lgc20200602-1700
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -19,7 +19,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.110.0.lgc20200601-1600</version>
+    <version>3.110.0.lgc20200602-1700</version>
     <packaging>eclipse-plugin</packaging>
       
     <properties>


### PR DESCRIPTION
This fix reverts a part of fix 
https://git.eclipse.org/c/platform/eclipse.platform.swt.git/commit/?id=eac6df5ed349eef5e48d660ddabd3b866528924e
https://bugs.eclipse.org/bugs/show_bug.cgi?id=469277

There were two main issues for that fix:
1. Tree cuts wide icons on the right
2. Trees that don't have any images, the rendering leaves a gap between the expando triangle and the item text

I tested these cases. With current changes: 
1. Tree doesn't cut wide icons but draws them incorrectly
2. There is not gap between expand icon and text

![image](https://user-images.githubusercontent.com/47422151/83526102-9c51ce00-a4ee-11ea-8e6a-4b1a36c1e2b7.png)

Since DSG doen't have wide icons we can use this fix. The root cause of blurred icons is the same that we had for MenuIcons - used scaled buffer. 

See results in attachments:
http://tfs:8080/tfs/IMPT/DS/_workitems/edit/690790
