### PR TITLE
Shell position

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -2741,7 +2741,6 @@ public void setVisible (boolean visible) {
 		}
 		opened = true;
 		if (!moved) {
-		    System.err.println("====");
 			moved = true;
 			Point location = getLocationInPixels();
 			oldX = location.x;

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.110.0.lgc20200602-1700
+Bundle-Version: 3.110.0.lgc20200617-1500
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -19,7 +19,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.110.0.lgc20200602-1700</version>
+    <version>3.110.0.lgc20200617-1500</version>
     <packaging>eclipse-plugin</packaging>
       
     <properties>


### PR DESCRIPTION
Problem: CCombo opens list in incorrect position in scaled mode

Analysis: SWT/GTK bug. The defect is reproducible in Eclipse IDE

[eclipse_doc_bug.zip](https://github.com/Halliburton-Landmark/eclipse.platform.swt/files/4792645/eclipse_doc_bug.zip)

The main workflow to reproduce the defect is
- shell.setBounds(..)
- shell.setVisible(..)

setVisible method has a code to save shell position https://github.com/eclipse/eclipse.platform.swt/commit/827e21430e04d8fe42a25c2caeaa1eeed2cae429

this part will send Move event again, values oldX and oldY get updates from gtk.
Sometimes gtk_window_get_position returns unscaled values, it might be a GTK bug and related to some delay, the similar problem for normal (not scaled) mode has been described in https://bugs.eclipse.org/bugs/show_bug.cgi?id=445900

Solution: don't sent Move event if shell position wasn't changed, update cached position for safety