### PR TITLE
Fix spinner text

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
@@ -15,9 +15,10 @@ package org.eclipse.swt.widgets;
 
 
 import org.eclipse.swt.*;
-import org.eclipse.swt.internal.win32.*;
-import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.events.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
+import org.eclipse.swt.internal.win32.*;
 
 /**
  * Instances of this class are selectable user interface
@@ -992,12 +993,26 @@ void setSelection (int value, boolean setPos, boolean setText, boolean notify) {
 			string = verifyText (string, 0, length, null);
 			if (string == null) return;
 		}
-		TCHAR buffer = new TCHAR (getCodePage (), string, true);
-		OS.SetWindowText (hwndText, buffer);
-		OS.SendMessage (hwndText, OS.EM_SETSEL, 0, -1);
-		OS.NotifyWinEvent (OS.EVENT_OBJECT_FOCUS, hwndText, OS.OBJID_CLIENT, 0);
+		setWindowText(string, notify);
+	} else {
+		if (notify) sendSelectionEvent (SWT.Selection);
 	}
-	if (notify) sendSelectionEvent (SWT.Selection);
+}
+
+private void setWindowText(String string, boolean notify) {
+    TCHAR buffer = new TCHAR (getCodePage (), string, true);
+    Runnable runnable = () -> {
+        OS.SetWindowText(hwndText, buffer);
+        OS.SendMessage(hwndText, OS.EM_SETSEL, 0, -1);
+        OS.NotifyWinEvent(OS.EVENT_OBJECT_FOCUS, hwndText, OS.OBJID_CLIENT, 0);
+        if (notify) sendSelectionEvent (SWT.Selection);
+    };
+    // Only on Windows, only with HiDPI we need to defer a call of OS.SetWindowText(hwndText, buffer);
+    if (DPIUtil.getDeviceZoom() > 150 && buffer.length() > 8) {
+        getDisplay().asyncExec(runnable);
+    } else {
+        runnable.run();
+    }
 }
 
 /**

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.110.0.lgc20200617-1500
+Bundle-Version: 3.110.0.lgc20200622-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -19,7 +19,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.110.0.lgc20200617-1500</version>
+    <version>3.110.0.lgc20200622-1200</version>
     <packaging>eclipse-plugin</packaging>
       
     <properties>


### PR DESCRIPTION
Analysis
Problem caused to internal implementation of spinner and is reproducible on simple SWT example also.
Problem is reproducible only on Windows and only with scaling.
I couldn't find any possibility to change Spinner's behavior.

Solution
I would suggest a hack. If defer setting of Spinner value then SWT repaints Spinner and value looks correctly.