### PR TITLE
PART 1 - Exception when exiting from App with no editors

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -954,6 +954,7 @@ public void create(Composite parent, int style) {
 					if (arg13.getType() == OLE.VT_BSTR) {
 						String text = arg13.getString();
 						StatusTextEvent newEvent5 = new StatusTextEvent(browser);
+						if (browser.isDisposed()) return;
 						newEvent5.display = browser.getDisplay();
 						newEvent5.widget = browser;
 						newEvent5.text = text;

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -454,8 +454,7 @@ public void create(Composite parent, int style) {
 
 	OleListener oleListener = event -> {
 		/* callbacks are asynchronous, auto could be disposed */
-		if (auto != null) {
-		  if (browser.isDisposed()) return;
+		if (auto != null && !browser.isDisposed()) {
 			switch (event.type) {
 				case BeforeNavigate2: {
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -455,6 +455,7 @@ public void create(Composite parent, int style) {
 	OleListener oleListener = event -> {
 		/* callbacks are asynchronous, auto could be disposed */
 		if (auto != null) {
+		  if (browser.isDisposed()) return;
 			switch (event.type) {
 				case BeforeNavigate2: {
 
@@ -954,7 +955,6 @@ public void create(Composite parent, int style) {
 					if (arg13.getType() == OLE.VT_BSTR) {
 						String text = arg13.getString();
 						StatusTextEvent newEvent5 = new StatusTextEvent(browser);
-						if (browser.isDisposed()) return;
 						newEvent5.display = browser.getDisplay();
 						newEvent5.widget = browser;
 						newEvent5.text = text;

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.110.0.lgc20200622-1200
+Bundle-Version: 3.110.0.lgc20200707-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -19,7 +19,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.110.0.lgc20200622-1200</version>
+    <version>3.110.0.lgc20200707-1200</version>
     <packaging>eclipse-plugin</packaging>
       
     <properties>


### PR DESCRIPTION
**Problem:** Exception when exiting from App with no editors. Parent get disposed due to event queue clearing in BrowserPanel.handleEvent. while(Display.getDefault().readAndDispatch()).

**Solution:** Add check for widget is disposed.

Part 2 - https://github.com/Halliburton-Landmark/eclipse.platform.ui/pull/31/