### PR TITLE
bugfix_702914 Linux PART 1 - Exception when exiting from App with no editors

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
@@ -2562,6 +2562,8 @@ void onDispose (Event e) {
 		if (!browser.isClosing) {
 			close (false);
 		}
+	} else {
+		return;
 	}
 
 	for (BrowserFunction function : functions.values()) {

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.110.0.lgc20200707-1200
+Bundle-Version: 3.110.0.lgc20201507-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.110.0.lgc20201507-1200
+Bundle-Version: 3.110.0.lgc20200715-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -19,7 +19,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.110.0.lgc20200707-1200</version>
+    <version>3.110.0.lgc20201507-1200</version>
     <packaging>eclipse-plugin</packaging>
       
     <properties>

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -19,7 +19,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.110.0.lgc20201507-1200</version>
+    <version>3.110.0.lgc20200715-1200</version>
     <packaging>eclipse-plugin</packaging>
       
     <properties>


### PR DESCRIPTION
**Problem:** Exception on Linux when exiting from App with no editors. Parent get disposed due to event queue clearing in BrowserPanel.handleEvent. while(Display.getDefault().readAndDispatch()).

org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4699)
	at org.eclipse.swt.SWT.error(SWT.java:4614)
	at org.eclipse.swt.SWT.error(SWT.java:4585)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:530)
	at org.eclipse.swt.widgets.Widget.getDisplay(Widget.java:616)
	at org.eclipse.swt.browser.WebKit.onDispose(WebKit.java:2596)
	at org.eclipse.swt.browser.WebKit.lambda$4(WebKit.java:1312)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5783)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1411)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1437)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1416)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1228)
	at org.eclipse.swt.widgets.Control.release(Control.java:4570)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
	at org.eclipse.swt.widgets.Control.release(Control.java:4570)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
	at org.eclipse.swt.widgets.Control.release(Control.java:4570)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
	at org.eclipse.swt.widgets.Control.release(Control.java:4570)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
	at org.eclipse.swt.widgets.Control.release(Control.java:4570)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
	at org.eclipse.swt.widgets.Control.release(Control.java:4570)
	at org.eclipse.swt.widgets.Widget.dispose(Widget.java:526)
	at org.eclipse.e4.ui.workbench.renderers.swt.SWTPartRenderer.disposeWidget(SWTPartRenderer.java:175)
	at org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer.disposeWidget(ContributedPartRenderer.java:273)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeRemoveGui(PartRenderingEngine.java:958)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$1(PartRenderingEngine.java:886)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:881)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)

**Solution:** Add check for widget is disposed.

PART 2 - https://github.com/Halliburton-Landmark/eclipse.platform.swt.binaries/pull/15