### PR TITLE
Backport fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=547933

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
@@ -148,6 +148,8 @@ class WebKit extends WebBrowser {
 	URI tlsErrorUri;
 	String tlsErrorType;
 
+	boolean firstLoad = true; //WebKit2 only
+
 	/**
 	 * Timeout used for javascript execution / deadlock detection.
 	 * Loosely based on the 10s limit commonly found in browsers.
@@ -3385,6 +3387,12 @@ long /*int*/ webkit_load_changed (long /*int*/ web_view, int status, long user_d
 			return handleLoadCommitted (uri, true);
 		}
 		case WebKitGTK.WEBKIT2_LOAD_FINISHED: {
+			if (firstLoad) {
+				GtkAllocation allocation = new GtkAllocation ();
+				GTK.gtk_widget_get_allocation(browser.handle, allocation);
+				GTK.gtk_widget_size_allocate(browser.handle, allocation);
+				firstLoad = false;
+			}
 			addEventHandlers (web_view, true);
 
 			long /*int*/ title = WebKitGTK.webkit_web_view_get_title (webView);

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.110.0.lgc20200715-1300
+Bundle-Version: 3.110.0.lgc20210413-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -19,7 +19,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.110.0.lgc20200715-1300</version>
+    <version>3.110.0.lgc20210413-1200</version>
     <packaging>eclipse-plugin</packaging>
       
     <properties>


### PR DESCRIPTION
Backport Eclipse fix https://bugs.eclipse.org/bugs/show_bug.cgi?id=547933

https://github.com/eclipse/eclipse.platform.swt/commit/683d01a40d6ac17c596b7d2017f940efce8135cd#diff-2503f62f5043cef8860d6d51acf6f12a0c0ba274fa122ac5193188c31b6aaac5

Original defect requested these changes is ADO 281119

Additional: https://github.com/Halliburton-Landmark/eclipse.platform.swt.binaries/pull/16

@ybova @mastanarao 