### PR TITLE
Revert fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=294300

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -3122,15 +3122,22 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 		long g_class = OS.g_type_class_peek_parent (OS.G_OBJECT_GET_CLASS (cell));
 		GtkCellRendererClass klass = new GtkCellRendererClass ();
 		OS.memmove (klass, g_class);
-		if (GTK.GTK_IS_CELL_RENDERER_TEXT (cell)) {
-			/*
-			 * SWT.FOREGROUND means the Table is responsible for painting the default foreground
-			 * color. This can be either the system default (COLOR_LIST_FOREGROUND), or the
-			 * color set by setForeground(). See bug 294300.
-			 */
-			GdkRGBA rgba = foreground != null ? foreground : display.getSystemColor(SWT.COLOR_LIST_FOREGROUND).handle;
-			OS.g_object_set (cell, OS.foreground_rgba, rgba, 0);
+
+		// temporary revert fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=294300
+		// since it produces regression described at https://bugs.eclipse.org/bugs/show_bug.cgi?id=294300#c9
+		// it is better to wait for the proper solution from SWT side
+		if (drawForegroundRGBA != null && GTK.GTK_IS_CELL_RENDERER_TEXT (cell)) {
+		    OS.g_object_set (cell, OS.foreground_rgba, drawForegroundRGBA, 0);
 		}
+//		if (GTK.GTK_IS_CELL_RENDERER_TEXT (cell)) {
+//			/*
+//			 * SWT.FOREGROUND means the Table is responsible for painting the default foreground
+//			 * color. This can be either the system default (COLOR_LIST_FOREGROUND), or the
+//			 * color set by setForeground(). See bug 294300.
+//			 */
+//			GdkRGBA rgba = foreground != null ? foreground : display.getSystemColor(SWT.COLOR_LIST_FOREGROUND).handle;
+//			OS.g_object_set (cell, OS.foreground_rgba, rgba, 0);
+//		}
 		if (GTK.GTK4) {
 			OS.call (klass.snapshot, cell, snapshot, widget, background_area, cell_area, drawFlags);
 		} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -3325,15 +3325,22 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 		long g_class = OS.g_type_class_peek_parent (OS.G_OBJECT_GET_CLASS (cell));
 		GtkCellRendererClass klass = new GtkCellRendererClass ();
 		OS.memmove (klass, g_class);
-		if (GTK.GTK_IS_CELL_RENDERER_TEXT (cell)) {
-			/*
-			 * SWT.FOREGROUND means the Tree is responsible for painting the default foreground
-			 * color. This can be either the system default (COLOR_LIST_FOREGROUND), or the
-			 * color set by setForeground(). See bug 294300.
-			 */
-			GdkRGBA rgba = foreground != null ? foreground : display.getSystemColor(SWT.COLOR_LIST_FOREGROUND).handle;
-			OS.g_object_set (cell, OS.foreground_rgba, rgba, 0);
+
+		// temporary revert fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=294300
+		// since it produces regression described at https://bugs.eclipse.org/bugs/show_bug.cgi?id=294300#c9
+		// it is better to wait for the proper solution from SWT side
+		if (drawForegroundRGBA != null && GTK.GTK_IS_CELL_RENDERER_TEXT (cell)) {
+		    OS.g_object_set (cell, OS.foreground_rgba, drawForegroundRGBA, 0);
 		}
+//		if (GTK.GTK_IS_CELL_RENDERER_TEXT (cell)) {
+//			/*
+//			 * SWT.FOREGROUND means the Tree is responsible for painting the default foreground
+//			 * color. This can be either the system default (COLOR_LIST_FOREGROUND), or the
+//			 * color set by setForeground(). See bug 294300.
+//			 */
+//			GdkRGBA rgba = foreground != null ? foreground : display.getSystemColor(SWT.COLOR_LIST_FOREGROUND).handle;
+//			OS.g_object_set (cell, OS.foreground_rgba, rgba, 0);
+//		}
 		if (GTK.GTK4) {
 			OS.call (klass.snapshot, cell, snapshot, widget, background_area, cell_area, drawFlags);
 		} else {

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.123.0.lgc20231030-1600
+Bundle-Version: 3.123.0.lgc20240313-2300
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.123.0.lgc20231030-1600</version>
+    <version>3.123.0.lgc20240313-2300</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>


### PR DESCRIPTION
Revert Eclipse fix https://git.eclipse.org/r/c/platform/eclipse.platform.swt/+/137235/

The defect requested these changes is ADO 1200310 (Linux: Data items color in depth domain is black in inventory)

I would like to revert Eclipse's fix instead of fixing it. The original SWT defect has been reported in 2009, and we never had an issue with that. We can pick-up the proper fix with the next updates.
The issue can be reproduced outside of our application, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=294300#c9

Binaries: https://github.com/Halliburton-Landmark/eclipse.platform.swt.binaries/pull/21