### PR TITLE
missed space symbol in manifest

### DIFF
--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.124.200.lgc20240523-1900
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2
-Export-Package:
+Export-Package: 
  org.eclipse.swt,
  org.eclipse.swt.accessibility,
  org.eclipse.swt.awt,


### PR DESCRIPTION
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-packaging-plugin:4.0.4:package-plugin (default-package-plugin) on project org.eclipse.swt: Error assembling JAR: invalid header field (line 9) -> [Help 1]