### PR TITLE
[Gtk] Ignore transparency when setting Combo popup color (Fix for a Bug 1657353)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -2716,6 +2716,17 @@ void updateCss() {
 	// Deal with background
 	if (background != null) {
 		final String colorString = display.gtk_rgba_to_css_string(background);
+		GdkRGBA menuBackground = new GdkRGBA();
+		menuBackground.red = background.red;
+		menuBackground.green = background.green;
+		menuBackground.blue = background.blue;
+		menuBackground.alpha = 1.0;
+		/* Ensures that the popup menu is not transparent and as a result unreadable
+		 * This way effects like "light" transparency (alpha > 0.85) can not be achieved.
+		 * Having any transparency of the popup is generally unwanted as it hurts visibility so
+		 * if such a feature is usable to anyone it would need new dedicated API.
+		 */
+		final String menuColorString = display.gtk_rgba_to_css_string(menuBackground);
 
 		/*
 		 * Use 'background:' instead of 'background-color:' to also override
@@ -2723,7 +2734,7 @@ void updateCss() {
 		 * 'background-image:' for 'GtkToggleButton' used in READ_ONLY combo.
 		 */
 		css.append("* {background: " + colorString + ";}\n");
-		css.append("menu {background: " + colorString + ";}\n");
+		css.append("menu {background: " + menuColorString + ";}\n");
 
 		/*
 		 * Setting background color for '*' also affects selection background,

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.124.200.lgc20240523-1900
+Bundle-Version: 3.124.200.lgc20260407-1900
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.124.200.lgc20240523-1900</version>
+    <version>3.124.200.lgc20260407-1900</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>


### PR DESCRIPTION
Fix for a Bug 1657353: Cherry-pick of transparent background issue fix from https://github.com/eclipse-platform/eclipse.platform.swt/commit/28bb9b45c276cc5ed176ccff313ed727f607f3e9
